### PR TITLE
修复sed变量替换中正则匹配错误

### DIFF
--- a/base/03_text_processing.rst
+++ b/base/03_text_processing.rst
@@ -348,7 +348,7 @@ sed 文本替换利器
 已匹配的字符串通过标记&来引用.
 ::
 
-	echo this is en example | sed 's/\w+/[&]/g'
+	echo this is en example | sed 's/\w\+/[&]/g'
 	$>[this]  [is] [en] [example]
 
 


### PR DESCRIPTION
sed正则匹配中 "+" 号 默认匹配 +号 , "\\+" 才是匹配一次或多次, 这里与通常正则表达式中相反.
两种修改: 
1.  echo this is en example | sed 's/\w\+/[&]/g'
2. echo this is en example | sed -r 's/\w+/[&]/g'